### PR TITLE
Deprecated API fields fixes

### DIFF
--- a/deploy/webhook-registration.yaml.tpl
+++ b/deploy/webhook-registration.yaml.tpl
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: pod-annotate-webhook
@@ -11,6 +11,8 @@ metadata:
     kind: mutator
 webhooks:
   - name: pod-annotate-webhook.kata.xyz
+    sideEffects: None
+    admissionReviewVersions: ["v1"]
     clientConfig:
       service:
         name: pod-annotate-webhook


### PR DESCRIPTION
* Fixed api version of the `MutatingWebhookConfiguration` resource
* Added both `sideEffects` and  `admissionReviewVersions` fields because their default value is now removed and these field made required. (according to https://kubernetes.io/docs/reference/using-api/deprecation-guide/)